### PR TITLE
Moved the setup requirements for setup.py to pyproject.toml. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ['setuptools', 'cython', 'numpy', 'scikit-learn', 'gurobipy', 'cvxpy']

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ LICENSE = 'LICENSE.txt'
 DOWNLOAD_URL = 'https://github.com/aia-uclouvain/pydl8.5'
 VERSION = __version__
 INSTALL_REQUIRES = ['setuptools', 'cython', 'numpy', 'scikit-learn', 'gurobipy', 'cvxpy']
-SETUP_REQUIRES = ['setuptools', 'cython', 'numpy', 'scikit-learn', 'gurobipy', 'cvxpy']
 KEYWORDS = ['decision trees', 'discrete optimization', 'classification']
 CLASSIFIERS = ['Programming Language :: Python :: 3',
                'License :: OSI Approved :: MIT License',
@@ -90,7 +89,6 @@ setup(
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     classifiers=CLASSIFIERS,
-    setup_requires=SETUP_REQUIRES,
     install_requires=INSTALL_REQUIRES,
     # extras_require=EXTRAS_REQUIRE,
     zip_safe=True,  # the package can run out of an .egg file


### PR DESCRIPTION
The advantage is pip can resolve the setup requirements before installing the package which prevents issues like "ModuleNotFoundError: No module named 'cvxpy'" when using pip install pydl8.5 or "python3 setup.py install" (screencaps below). Now anyone can simply clone the repo and do `pip install .` (or `pip install pydl8.5` which in theory should work with PyPI). 

![Screenshot from 2022-05-15 23-19-55](https://user-images.githubusercontent.com/26820345/168494841-27c202d3-fdf6-478a-84b7-24d7bcdac9e4.png)
![Screenshot from 2022-05-15 23-21-05](https://user-images.githubusercontent.com/26820345/168494872-1ef96877-c6f5-47d3-9fba-b021c25e5839.png)



